### PR TITLE
Resolve timing issues with MIDI data serialization

### DIFF
--- a/Fifo.h
+++ b/Fifo.h
@@ -1,0 +1,59 @@
+#pragma once
+
+/// Simple FIFO implementation.
+///
+/// @param[in] T is the base type of the elements
+/// @param[in] S is the capacity of the buffer
+///
+/// The buffer can be configured to hold up to 255 elements.
+/// If this size will be not enough, the implementation of
+/// class has to be witched to int size, however this would
+/// mean performance penalty on the 8-bit MCU.
+template <typename T, byte S>
+class Fifo {
+  public:
+
+    /// Checks if the buffer is empty.
+    bool empty() const {
+      return m_size == 0;
+    }
+
+    /// Checks if the buffer is full.
+    bool full() const {
+      return m_size >= S;
+    }
+
+    /// Adds an element to the end of the buffer.
+    ///
+    /// @param[in] element is the element to add
+    /// @return false if the buffer is already full
+    bool push(const T& element) {
+      if (full()) {
+        return false;
+      }
+      m_buffer[(m_first + m_size) % S] = element;
+      m_size++;
+      return true;
+    }
+
+    /// Removes an element from the head of the buffer.
+    /// @return The first element, if available
+    T pop() {
+      // If this function was called on an empty buffer, it's the
+      // fault of the user. Normal implementation would throw
+      // an exception, but we don't do such things here, so let's
+      // simply return something;
+      if (empty()) {
+        return T{};
+      }
+
+      const auto result = m_buffer[m_first++];
+      m_size--;
+      return result;
+    }
+
+  private:
+    T m_buffer[S];
+    byte m_first{0};
+    byte m_size{0};
+};

--- a/Fifo.h
+++ b/Fifo.h
@@ -48,7 +48,7 @@ class Fifo {
       // If this function was called on an empty buffer, it's the
       // fault of the user. Normal implementation would throw
       // an exception, but we don't do such things here, so let's
-      // simply return something;
+      // simply return something
       if (empty()) {
         return T{};
       }

--- a/LPT2MIDI.ino
+++ b/LPT2MIDI.ino
@@ -1,6 +1,6 @@
 #include "Fifo.h"
 
-static Fifo<byte, 128> fifo;
+static Fifo<byte, 192> fifo;
 
 void setup() {
   static byte MASKB = B00000111; // Using lower 3 bits of the B port

--- a/LPT2MIDI.ino
+++ b/LPT2MIDI.ino
@@ -9,8 +9,8 @@ void setup() {
   DDRB &= ~MASKB;
   DDRD &= ~MASKD;
   Serial.begin(31250);
-  auto recieve = []() { fifo.push(((PIND & MASKD) >> 3) | ((PINB & MASKB) << 5)); };
-  attachInterrupt(digitalPinToInterrupt(2), recieve, RISING);
+  auto receive = []() { fifo.push(((PIND & MASKD) >> 3) | ((PINB & MASKB) << 5)); };
+  attachInterrupt(digitalPinToInterrupt(2), receive, RISING);
 }
 
 void loop() {

--- a/LPT2MIDI.ino
+++ b/LPT2MIDI.ino
@@ -1,14 +1,23 @@
-/* remember to chage SERIAL_TX_BUFFER_SIZE 512 in HardwareSerial.h so large sysex's go through as well */
-void receive() {
-  Serial.write((PIND>>3) + (PINB<<5));
-}
+#include "Fifo.h"
+
+static Fifo<byte, 128> fifo;
 
 void setup() {
-  DDRB = 0;
-  DDRD = 0;
+  static byte MASKB = B00000111; // Using lower 3 bits of the B port
+  static byte MASKD = B11111000; // Using upper 5 bits of the D port
+  // Set only the required bits to input, leaving all the other bits unchanged
+  DDRB &= ~MASKB;
+  DDRD &= ~MASKD;
   Serial.begin(31250);
-  attachInterrupt(digitalPinToInterrupt(2), receive, RISING);
+  auto recieve = []() { fifo.push(((PIND & MASKD) >> 3) | ((PINB & MASKB) << 5)); };
+  attachInterrupt(digitalPinToInterrupt(2), recieve, RISING);
 }
 
 void loop() {
+  // TODO: we could check here for fifo overflow using the fifo.full()
+  //       function and notifying somehow the user. May be by blinking
+  //       the LED?
+  if (!fifo.empty()) {
+    Serial.write(fifo.pop());
+  }
 }


### PR DESCRIPTION
The initial implementation calls Serial.write(...) in the interrupt handler. This is undefined behavior and is actually not allowed, since it can end up in unstable timing behavior and lost data packets, even if it seems to work sometimes.

This patch introduces a FIFO buffer, which gets filled in the interrupt handler and the data serialization itself happens in the main loop. This solution should also make the manipulation of the SERIAL_RX_BUFFER_SIZE macro obsolete and improves the compatibility with different toolchains.